### PR TITLE
SJSON parser able to detect duplicate dictionary keys and output them as warnings and fixed other bugs

### DIFF
--- a/src/archivar.js
+++ b/src/archivar.js
@@ -46,20 +46,43 @@ function processJbeamFile(filename) {
     let dataBundle
     try {
       dataBundle = sjsonParser.decodeWithMeta(contentTextUtf8, filename, false) // false to be able to json encode
-      if(dataBundle.errors.length > 0) {
-        for(let e of dataBundle.errors) {
-          const pos = new vscode.Position(
-            e.range ? e.range[0] : e.line ? e.line : 0,
-            e.range ? e.range[1] : e.column ? e.column : 0
-          )
-          const diagnostic = new vscode.Diagnostic(
-            new vscode.Range(pos, pos),
-            `Error parsing json file ${filename}`,
-            vscode.DiagnosticSeverity.Error
-          );
-          diagnosticsList.push(diagnostic);
+      if (dataBundle) {
+        if(dataBundle.errors && dataBundle.errors.length > 0) {
+          for(let e of dataBundle.errors) {
+            const startPos = new vscode.Position(
+              e.range ? e.range[0] : e.line ? e.line : 0,
+              e.range ? e.range[1] : e.column ? e.column : 0
+            )
+            const endPos = new vscode.Position(
+              e.range ? e.range[2] : e.line ? e.line : 0,
+              e.range ? e.range[3] : e.column ? e.column : 0
+            )
+            const diagnostic = new vscode.Diagnostic(
+              new vscode.Range(startPos, endPos),
+              `Json error: ${e.message}`,
+              vscode.DiagnosticSeverity.Error
+            );
+            diagnosticsList.push(diagnostic);
+          }
         }
-
+        if(dataBundle.warnings && dataBundle.warnings.length > 0) {
+          for(let w of dataBundle.warnings) {
+            const startPos = new vscode.Position(
+              w.range ? w.range[0] : w.line ? w.line : 0,
+              w.range ? w.range[1] : w.column ? w.column : 0
+            )
+            const endPos = new vscode.Position(
+              w.range ? w.range[2] : w.line ? w.line : 0,
+              w.range ? w.range[3] : w.column ? w.column : 0
+            )
+            const diagnostic = new vscode.Diagnostic(
+              new vscode.Range(startPos, endPos),
+              `Json warning: ${w.message}`,
+              vscode.DiagnosticSeverity.Warning
+            );
+            diagnosticsList.push(diagnostic);
+          }
+        }
         //console.error(`Error parsing json file ${filename} - ${JSON.stringify(dataBundle.errors, null, 2)}`)
       }
     } catch (e) {

--- a/src/archivar.js
+++ b/src/archivar.js
@@ -159,13 +159,14 @@ function removeJbeamFileData(filename) {
   if (!jbeamFileData || !jbeamFileData[namespace] || !jbeamFileData[namespace][filename]) {
     return
   }
-  for(let partName in jbeamFileData[namespace][filename]) {
+  for(let partName in jbeamFileData[namespace][filename].data) {
     if(partData[namespace][partName]) {
       delete(partData[namespace][partName])
       partCounter--
     }
   }
   delete(jbeamFileData[namespace][filename])
+  jbeamFileCounter--
   //console.log(`Deleted ${deletedParts} parts from file ${filename}`)
 }
 

--- a/src/archivar.js
+++ b/src/archivar.js
@@ -81,8 +81,12 @@ function processJbeamFile(filename) {
         // w[0] = type: error/warning
         // w[1] = message
         // w[2] = range = [linefrom, positionfrom, lineto, positionto]
+        let linefrom = 0, positionfrom = 0, lineto = 0, positionto = 0
+        if (w[2]) {
+          linefrom = w[2][0], positionfrom = w[2][1], lineto = w[2][2], positionto = w[2][3]
+        }
         const diagnostic = new vscode.Diagnostic(
-          new vscode.Range(new vscode.Position(w[2][0], w[2][1]), new vscode.Position(w[2][2], w[2][3])),
+          new vscode.Range(new vscode.Position(linefrom, positionfrom), new vscode.Position(lineto, positionto)),
           w[1],
           w[0] == 'warning' ? vscode.DiagnosticSeverity.Warning : vscode.DiagnosticSeverity.Error
         );

--- a/src/extension.js
+++ b/src/extension.js
@@ -23,7 +23,7 @@
 */
 const vscode = require('vscode');
 const threeDPreview = require('./threeDPreview');
-const jbeamSyntaxChecker = require('./jbeam/syntaxChecker');
+//const jbeamSyntaxChecker = require('./jbeam/syntaxChecker');
 const jbeamSymbolProviderExt = require('./jbeam/symbolProvider');
 const jbeamHoverProvider = require('./jbeam/hoverProvider');
 const logProcessor = require('./logparser/logProcessor');
@@ -37,17 +37,17 @@ function activate(context) {
   context.subscriptions.push(vscode.commands.registerCommand('jbeam-editor.syncWithSim', function () {
     simConnection.sync()
   }))
-  
+
   context.subscriptions.push(vscode.commands.registerCommand('jbeam-editor.openSettings', function () {
     vscode.commands.executeCommand('workbench.action.openSettings', '@ext:beamng.jbeam-editor');
   }))
 
   context.subscriptions.push(vscode.workspace.onDidChangeConfiguration(event => {
     // Check if the change affects your extension's configuration: reload everything affected
-    
+
     if (event.affectsConfiguration('jbeam-editor')) {
       threeDPreview.deactivate()
-      jbeamSyntaxChecker.deactivate()
+      //jbeamSyntaxChecker.deactivate()
       jbeamSymbolProviderExt.deactivate()
       jbeamHoverProvider.deactivate()
       archivar.deactivate()
@@ -56,7 +56,7 @@ function activate(context) {
 
       archivar.activate(context)
       threeDPreview.activate(context)
-      jbeamSyntaxChecker.activate(context)
+      //jbeamSyntaxChecker.activate(context)
       jbeamSymbolProviderExt.activate(context)
       jbeamHoverProvider.activate(context)
     }
@@ -70,13 +70,13 @@ function activate(context) {
       partconfigValidationCompletion.deactivate()
       partconfigValidationCompletion.activate(context)
     }
-    
+
   }))
 
   archivar.activate(context)
   simConnection.activate(context)
   threeDPreview.activate(context)
-  jbeamSyntaxChecker.activate(context)
+  //jbeamSyntaxChecker.activate(context)
   jbeamSymbolProviderExt.activate(context)
   jbeamHoverProvider.activate(context)
   logProcessor.activate(context)
@@ -88,7 +88,7 @@ function deactivate() {
   archivar.deactivate()
   simConnection.deactivate()
   threeDPreview.deactivate()
-  jbeamSyntaxChecker.deactivate()
+  //jbeamSyntaxChecker.deactivate()
   jbeamSymbolProviderExt.deactivate()
   jbeamHoverProvider.deactivate()
   dataView.deactivate()

--- a/src/json/tableSchema.js
+++ b/src/json/tableSchema.js
@@ -86,8 +86,8 @@ function processTableWithSchemaDestructive(jbeamTable, inputOptions, diagnostics
     // empty section
     return 0
   }
-  if (typeof header !== "object" || header.__meta.type !== 'array') {
-    diagnostics.push(['error', 'Invalid table header', header.__meta.range])
+  if (typeof header !== "object") {
+    diagnostics.push(['error', 'Invalid table header', header.__meta?.range])
     return -1
   }
 
@@ -112,7 +112,7 @@ function processTableWithSchemaDestructive(jbeamTable, inputOptions, diagnostics
   for (const rowKey of keys) {
     let rowValue = jbeamTable[rowKey];
     if (typeof rowValue !== "object") {
-      diagnostics.push(['error', 'Invalid table row', rowValue.__meta.range])
+      diagnostics.push(['error', 'Invalid table row', rowValue.__meta?.range])
       return -1
     }
     if (rowValue.__meta.type !== 'array') {
@@ -128,7 +128,7 @@ function processTableWithSchemaDestructive(jbeamTable, inputOptions, diagnostics
           diagnostics.push(['error', `Inline option (argument ${headerSize + 1}) need to be a dict, not a ${typeof rowValue[headerSize]}: ${rowValue[headerSize]}`, rowValue.__meta.range])
         }
       } else if (rowSize > headerSize + 1) {
-        let msg = 1`Invalid table header, must be as long as all table cells (plus one additional options column):\n`;
+        let msg = `Invalid table header, must be as long as all table cells (plus one additional options column):\n`;
         msg += `Table header: ${JSON.stringify(header)}\n`
         msg += `Mismatched row: ${JSON.stringify(rowValue)}`
         diagnostics.push(['error', msg, rowValue.__meta.range])


### PR DESCRIPTION
- SJSON parser able to detect duplicate dictionary keys and output them as warnings
- Also added ability to specify start/end line/column number for calling jsonWarning() and jsonError() functions
- Now all files in the workspace directory are parsed and checks their syntax, after fixing bug with pushing diagnostic errors
- Disabled the single jbeam file parser/syntax checker to avoid displaying duplicate error/warning messages
- Fixed JBeam file and part counter