### PR TITLE
Fixed diagnosing files outside of the workspace, code fixes, and better error handling

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -23,7 +23,7 @@
 */
 const vscode = require('vscode');
 const threeDPreview = require('./threeDPreview');
-//const jbeamSyntaxChecker = require('./jbeam/syntaxChecker');
+const jbeamSyntaxChecker = require('./jbeam/syntaxChecker');
 const jbeamSymbolProviderExt = require('./jbeam/symbolProvider');
 const jbeamHoverProvider = require('./jbeam/hoverProvider');
 const logProcessor = require('./logparser/logProcessor');
@@ -47,7 +47,7 @@ function activate(context) {
 
     if (event.affectsConfiguration('jbeam-editor')) {
       threeDPreview.deactivate()
-      //jbeamSyntaxChecker.deactivate()
+      jbeamSyntaxChecker.deactivate()
       jbeamSymbolProviderExt.deactivate()
       jbeamHoverProvider.deactivate()
       archivar.deactivate()
@@ -56,7 +56,7 @@ function activate(context) {
 
       archivar.activate(context)
       threeDPreview.activate(context)
-      //jbeamSyntaxChecker.activate(context)
+      jbeamSyntaxChecker.activate(context)
       jbeamSymbolProviderExt.activate(context)
       jbeamHoverProvider.activate(context)
     }
@@ -76,7 +76,7 @@ function activate(context) {
   archivar.activate(context)
   simConnection.activate(context)
   threeDPreview.activate(context)
-  //jbeamSyntaxChecker.activate(context)
+  jbeamSyntaxChecker.activate(context)
   jbeamSymbolProviderExt.activate(context)
   jbeamHoverProvider.activate(context)
   logProcessor.activate(context)
@@ -88,7 +88,7 @@ function deactivate() {
   archivar.deactivate()
   simConnection.deactivate()
   threeDPreview.deactivate()
-  //jbeamSyntaxChecker.deactivate()
+  jbeamSyntaxChecker.deactivate()
   jbeamSymbolProviderExt.deactivate()
   jbeamHoverProvider.deactivate()
   dataView.deactivate()

--- a/src/jbeam/hoverProvider.js
+++ b/src/jbeam/hoverProvider.js
@@ -102,7 +102,7 @@ class JBeamHoverProvider {
 
       let metaRaw = sjsonParser.getMetaForCurAnyData(dataBundle.data, position.line, position.character, document.uri, 'raw', 1)
       if(!metaRaw || metaRaw.length == 0) {
-        console.log('unable to get data below cursor: ', document.uri.fsPath, text, position)
+        console.log('unable to get data below cursor: ', document.uri.fsPath, word, position)
         return
       }
 

--- a/src/jbeam/symbolProvider.js
+++ b/src/jbeam/symbolProvider.js
@@ -20,7 +20,7 @@ class JBeamSymbolProvider {
     let [tableInterpretedData, diagnostics] = tableSchema.processAllParts(dataBundle.data)
 
     for (const [partName, part] of Object.entries(tableInterpretedData)) {
-      if(partName === '__meta' || part.__meta === undefined) continue
+      if(partName === '__meta' || part?.__meta === undefined) continue
       const range = new vscode.Range(
         new vscode.Position(part.__meta.range[0], part.__meta.range[1]),
         new vscode.Position(part.__meta.range[2], part.__meta.range[3])

--- a/src/json/sjsonParser.js
+++ b/src/json/sjsonParser.js
@@ -509,11 +509,11 @@ function decodeWithMeta(s, origin, cyclicDependencies = true) {
   }
 }
 
-function decodeWithMetaWithDiagnostics(contentTextUtf8, filename) {
+function decodeWithMetaWithDiagnostics(contentTextUtf8, filename, cyclicDependencies = true) {
   let dataBundle
   let diagnosticsList = []
   try {
-    dataBundle = decodeWithMeta(contentTextUtf8, filename);
+    dataBundle = decodeWithMeta(contentTextUtf8, filename, cyclicDependencies);
   } catch (e) {
     const pos = new vscode.Position(
       e.range ? e.range[0] : e.line ? e.line : 0,
@@ -564,7 +564,7 @@ function decodeWithMetaWithDiagnostics(contentTextUtf8, filename) {
       }
     }
   }
-  
+
   dataBundle.diagnosticsList = diagnosticsList
   return dataBundle
 }

--- a/src/threeDPreview.js
+++ b/src/threeDPreview.js
@@ -252,7 +252,7 @@ function show3DSceneCommand() {
         partNameFound = partName
         for (let sectionName in part) {
           const section = part[sectionName]
-          if(section.__meta.range) {
+          if(typeof section === "object" && section.__meta?.range) {
             if (range[0] >= section.__meta.range[0] && range[0] <= section.__meta.range[2]) {
               sectionNameFound = sectionName
               break


### PR DESCRIPTION
Now able to perform diagnostics on jbeam files outside of the workspace, and a better solution for avoiding displaying duplicate errors/warnings by diagnosing the open jbeam file separately from the workspace jbeam files. Also fixed code and better error handling.